### PR TITLE
Renamed the ‘Get entry tasks’ action to ‘Search entry tasks’

### DIFF
--- a/Apps.Contentful/Actions/EntryTaskActions.cs
+++ b/Apps.Contentful/Actions/EntryTaskActions.cs
@@ -16,7 +16,7 @@ namespace Apps.Contentful.Actions;
 [ActionList]
 public class EntryTaskActions(InvocationContext invocationContext) : ContentfulInvocable(invocationContext)
 {
-    [Action("Get entry tasks", Description = "Get all entry tasks for a specific entry")]
+    [Action("Search entry tasks", Description = "Search for entry tasks by specific criteria")]
     public async Task<GetEntryTasksResponse> GetEntryTasks([ActionParameter] EntryIdentifier identifier)
     {
         var client = new ContentfulRestClient(Creds, identifier.Environment);

--- a/Apps.Contentful/Apps.Contentful.csproj
+++ b/Apps.Contentful/Apps.Contentful.csproj
@@ -6,7 +6,7 @@
         <Nullable>enable</Nullable>
         <Product>Contentful</Product>
         <Description>The headless content management system</Description>
-        <Version>1.5.1</Version>
+        <Version>1.5.2</Version>
         <AssemblyName>Apps.Contentful</AssemblyName>
     </PropertyGroup>
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Finally, you can specify a list of Field IDs which will always be ignored and no
 
 ### Entry tasks
 
-- **Get entry tasks** returns a list of tasks for the specified entry.
+- **Search entry tasks** returns a list of tasks based on the specified filters.
 - **Get entry task** returns details of a specific task.
 - **Update entry task** updates an entry task with new details.
 
@@ -148,7 +148,6 @@ Note, to use the **Entry tasks** actions, you need to install the `Workflows` ap
 - **On asset archived**
 - **On asset unarchived**
 - **On asset deleted**
-
 
 ## Examples
 


### PR DESCRIPTION
Renamed the ‘Get entry tasks’ action to ‘Search entry tasks’