### PR TITLE
fix: extract inline linked entry IDs from HTML <a> elements

### DIFF
--- a/Apps.Contentful/Actions/EntryActions.cs
+++ b/Apps.Contentful/Actions/EntryActions.cs
@@ -810,6 +810,23 @@ public class EntryActions(InvocationContext invocationContext, IFileManagementCl
                 }
             }
         }
+        var inlineLinkNodes = doc.DocumentNode.SelectNodes("//a[starts-with(@id, 'embedded-entry-inline_')]");
+        if (inlineLinkNodes != null)
+        {
+            const string prefix = "embedded-entry-inline_";
+            foreach (var node in inlineLinkNodes)
+            {
+                var idAttr = node.GetAttributeValue("id", string.Empty);
+                if (!string.IsNullOrEmpty(idAttr) && idAttr.StartsWith(prefix))
+                {
+                    var extractedId = idAttr.Substring(prefix.Length);
+                    if (!string.IsNullOrEmpty(extractedId))
+                    {
+                        entryIds.Add(extractedId);
+                    }
+                }
+            }
+        }
 
         return entryIds.Distinct();
     }

--- a/Apps.Contentful/Actions/TagActions.cs
+++ b/Apps.Contentful/Actions/TagActions.cs
@@ -9,6 +9,7 @@ using Apps.Contentful.Models.Responses.Tags;
 using Apps.Contentful.Utils;
 using Blackbird.Applications.Sdk.Common;
 using Blackbird.Applications.Sdk.Common.Actions;
+using Blackbird.Applications.Sdk.Common.Exceptions;
 using Blackbird.Applications.Sdk.Common.Invocation;
 using Blackbird.Applications.Sdk.Utils.Extensions.Http;
 using RestSharp;
@@ -66,6 +67,16 @@ public class TagActions(InvocationContext invocationContext) : ContentfulInvocab
     [Action("Add tag to entry", Description = "Add specific tag to an entry")]
     public async Task AddEntryTag([ActionParameter] EntryTagIdentifier input)
     {
+        if (string.IsNullOrEmpty(input.TagId))
+        {
+            throw new PluginMisconfigurationException("Tag ID is null or empty. Please input a valid ID");
+        }
+        
+        if (string.IsNullOrEmpty(input.EntryId))
+        {
+            throw new PluginMisconfigurationException("Entry ID is null or empty. Please input a valid ID");
+        }
+        
         var client = new ContentfulClient(Creds, input.Environment);
         var entry = await ExceptionWrapper.ExecuteWithErrorHandling(async () => await client.GetEntry(input.EntryId));
 
@@ -79,7 +90,7 @@ public class TagActions(InvocationContext invocationContext) : ContentfulInvocab
         var tags = entry.Metadata.Tags
             .Select(x => x.Sys.Id)
             .Append(input.TagId)
-            .Select(x => new PropertiesRequest()
+            .Select(x => new PropertiesRequest
             {
                 Sys = new()
                 {

--- a/Apps.Contentful/Apps.Contentful.csproj
+++ b/Apps.Contentful/Apps.Contentful.csproj
@@ -6,7 +6,7 @@
         <Nullable>enable</Nullable>
         <Product>Contentful</Product>
         <Description>The headless content management system</Description>
-        <Version>1.6.15</Version>
+        <Version>1.6.16</Version>
         <AssemblyName>Apps.Contentful</AssemblyName>
     </PropertyGroup>
 


### PR DESCRIPTION
Fixed issue with extracting inline linked entry IDs in 'Get IDs from HTML' action